### PR TITLE
fix: update import paths for parameter types

### DIFF
--- a/params.ts
+++ b/params.ts
@@ -1,7 +1,5 @@
 import * as coda from "@codahq/packs-sdk";
-import * as helpers from "./helpers";
-import * as schemas from "./schemas";
-import * as types from "types/pack-types";
+import * as types from "types/api-types";
 
 export const MediaDateRange = coda.makeParameter({
   type: coda.ParameterType.DateArray,


### PR DESCRIPTION
Simplify the import statements and update the import paths for the parameter types from "types/pack-types" to "types/api-types".