### PR TITLE
feat: relation between albums & medias

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,9 @@ Use this pack to synchronise your photos and albums right inside Coda!
   - [x] Filter photos by favorites
   - [x] Filter photos by date
   - [x] Filter photos by categories (include)
-  - [x] Filter photos by categories (exclude) (soon)
-- [ ] See which photos belong to what album (soon) [#5](https://github.com/siriusnottin/google-photos-pack/issues/5)
+  - [x] Filter photos by categories (exclude)
+- [x] See which photos belong to what album (soon) [#5](https://github.com/siriusnottin/google-photos-pack/issues/5)
 - [ ] Get details informations about an album or a photo (soon) [#6](https://github.com/siriusnottin/google-photos-pack/issues/6)
-- [ ] Refactor the code for better readability and organization (I’m still learning)
 
 ## Changelog
 

--- a/api/index.ts
+++ b/api/index.ts
@@ -7,6 +7,7 @@ import { MediaItems } from "./media-items";
 
 import { DateFilter } from "./common/date-filter";
 import { MediaTypeFilter } from "./media-items/media-type-filter";
+import { FeatureFilter } from "./media-items/feature-filter"
 import { ContentFilter } from "./media-items/content-filter";
 import { Filters } from "./media-items/filters";
 export default class GPhotos {
@@ -18,6 +19,7 @@ export default class GPhotos {
 
   public readonly DateFilter = DateFilter;
   public readonly MediaTypeFilter = MediaTypeFilter;
+  public readonly FeatureFilter = FeatureFilter;
   public readonly ContentFilter = ContentFilter;
   public readonly Filters = Filters;
 

--- a/api/index.ts
+++ b/api/index.ts
@@ -23,8 +23,8 @@ export default class GPhotos {
   public readonly ContentFilter = ContentFilter;
   public readonly Filters = Filters;
 
-  constructor(public readonly context: coda.ExecutionContext) {
-    this.transport = new Transport(context);
+  constructor(public readonly fetcher: coda.Fetcher) {
+    this.transport = new Transport(fetcher);
     this.albums = new Albums(this.transport);
     this.mediaItems = new MediaItems(this.transport);
   }

--- a/api/media-items/feature-filter.ts
+++ b/api/media-items/feature-filter.ts
@@ -1,0 +1,21 @@
+
+import { MediaFeature, MediaItemsFilter } from "types/api-types";
+
+export class FeatureFilter {
+  public includedFeatures: [MediaFeature];
+
+  constructor(includedFeature = MediaFeature.None) {
+    this.includedFeatures = [includedFeature];
+  }
+
+  setFeature(feature: MediaFeature) {
+    this.includedFeatures = [feature];
+  }
+
+  toJSON(): MediaItemsFilter['featureFilter'] {
+    return {
+      includedFeatures: this.includedFeatures
+    }
+  }
+
+}

--- a/api/media-items/filters.ts
+++ b/api/media-items/filters.ts
@@ -2,11 +2,13 @@ import { DateFilter } from "../common/date-filter";
 import { MediaTypeFilter } from "./media-type-filter";
 import { ContentFilter } from "./content-filter";
 import { MediaItemsFilter } from "types/api-types";
+import { FeatureFilter } from "./feature-filter";
 
 export class Filters {
   public dateFilter: DateFilter;
   public mediaTypeFilter: MediaTypeFilter;
   public contentFilter: ContentFilter;
+  public featureFilter: FeatureFilter;
 
   constructor(public includeArchivedMedia = false) { }
 
@@ -26,12 +28,17 @@ export class Filters {
     this.includeArchivedMedia = includeArchivedMedia;
   }
 
+  setFeatureFilter(featureFilter: FeatureFilter) {
+    this.featureFilter = featureFilter;
+  }
+
   toJSON(): MediaItemsFilter {
     return {
       dateFilter: this.dateFilter,
       mediaTypeFilter: this.mediaTypeFilter,
       contentFilter: this.contentFilter,
       includeArchivedMedia: this.includeArchivedMedia,
+      featureFilter: this.featureFilter,
     }
   }
 }

--- a/api/media-items/index.ts
+++ b/api/media-items/index.ts
@@ -4,7 +4,7 @@ import { Filters } from "./filters";
 export class MediaItems {
   constructor(public transport: Transport) { }
 
-  list(pageSize = 100, pageToken?: string) { // range: 25-100
+  list(pageToken?: string, pageSize = 100) { // range: 25-100
     return this.transport.get("mediaItems", { pageSize, pageToken });
   }
 
@@ -12,20 +12,19 @@ export class MediaItems {
     return this.transport.get(`mediaItems/${mediaItemId}`);
   }
 
-  search(albumIdOrFilters: string | Filters, fields?: string, pageSize = 100, pageToken?: string) {
-    const postData: {
+  search(albumIdOrFilters: string | Filters, pageToken?: string, pageSize = 100, fields?: string) {
+    const body: {
       pageSize?: number;
       pageToken?: string;
       albumId?: string;
       filters?: ReturnType<Filters["toJSON"]>;
     } = { pageSize, pageToken }
     if (typeof albumIdOrFilters === "string") {
-      postData.albumId = albumIdOrFilters;
+      body.albumId = albumIdOrFilters;
     } else {
-      postData.filters = albumIdOrFilters.toJSON();
+      body.filters = albumIdOrFilters.toJSON();
     }
-    JSON.stringify(postData);
-    return this.transport.post("mediaItems:search", postData, fields);
+    return this.transport.post("mediaItems:search", { fields }, body);
   }
 
 }

--- a/api/media-items/index.ts
+++ b/api/media-items/index.ts
@@ -12,7 +12,7 @@ export class MediaItems {
     return this.transport.get(`mediaItems/${mediaItemId}`);
   }
 
-  search(albumIdOrFilters: string | Filters, pageSize = 100, pageToken?: string) {
+  search(albumIdOrFilters: string | Filters, fields?: string, pageSize = 100, pageToken?: string) {
     const postData: {
       pageSize?: number;
       pageToken?: string;
@@ -25,7 +25,7 @@ export class MediaItems {
       postData.filters = albumIdOrFilters.toJSON();
     }
     JSON.stringify(postData);
-    return this.transport.post("mediaItems:search", postData);
+    return this.transport.post("mediaItems:search", postData, fields);
   }
 
 }

--- a/api/transport.ts
+++ b/api/transport.ts
@@ -1,4 +1,5 @@
 import * as coda from "@codahq/packs-sdk";
+import { ApiResponse } from "types/api-types";
 
 const ApiBaseUrl = "https://photoslibrary.googleapis.com/v1";
 
@@ -21,14 +22,14 @@ export class Transport {
   private createRequestParams(method: coda.FetchMethodType, url: string, body?: string): coda.FetchRequest {
     // middleware to add header
     return {
-      method: method,
-      url: url,
+      method,
+      url,
       headers: this.headers,
-      body: body,
+      body,
     };
   }
 
-  get(endpoint: string, params?: { [key: string]: any }) {
+  get(endpoint: string, params?: { [key: string]: any }): Promise<coda.FetchResponse<ApiResponse>> {
     const request = this.createRequestParams(
       "GET",
       this.createUrl(endpoint, params)
@@ -40,11 +41,12 @@ export class Transport {
     // TODO: implement upload method
   }
 
-  post(endpoint: string, options?: object) {
+  post(endpoint: string, options?: object, fields?: string): Promise<coda.FetchResponse<ApiResponse>> {
     const body = JSON.stringify(options) as string;
+    const params = { fields: fields }
     const request = this.createRequestParams(
       "POST",
-      this.createUrl(endpoint),
+      this.createUrl(endpoint, params),
       body
     );
     return this.context.fetcher.fetch(request);

--- a/api/transport.ts
+++ b/api/transport.ts
@@ -56,13 +56,12 @@ export class Transport {
     // TODO: implement upload method
   }
 
-  post(endpoint: string, options?: object, fields?: string): Promise<coda.FetchResponse<ApiResponse>> {
-    const body = JSON.stringify(options);
-    const params = { fields }
+  post(endpoint: string, params?: { [key: string]: any }, body?: any): Promise<coda.FetchResponse<ApiResponse>> {
+
     const request = this.createRequestParams(
       "POST",
       this.createUrl(endpoint, params),
-      body
+      JSON.stringify(body)
     );
     return this.withErrorHandling(() => this.fetcher.fetch(request));
   }

--- a/api/transport.ts
+++ b/api/transport.ts
@@ -58,7 +58,7 @@ export class Transport {
 
   post(endpoint: string, options?: object, fields?: string): Promise<coda.FetchResponse<ApiResponse>> {
     const body = JSON.stringify(options);
-    const params = { fields: fields }
+    const params = { fields }
     const request = this.createRequestParams(
       "POST",
       this.createUrl(endpoint, params),

--- a/api/transport.ts
+++ b/api/transport.ts
@@ -5,7 +5,7 @@ const ApiBaseUrl = "https://photoslibrary.googleapis.com/v1";
 
 export class Transport {
 
-  constructor(public readonly context: coda.ExecutionContext) { }
+  constructor(public readonly fetcher: coda.Fetcher) { }
 
   private readonly headers = {
     "Content-Type": "application/json",
@@ -49,7 +49,7 @@ export class Transport {
       "GET",
       this.createUrl(endpoint, params)
     );
-    return this.withErrorHandling(() => this.context.fetcher.fetch(request));
+    return this.withErrorHandling(() => this.fetcher.fetch(request));
   }
 
   upload() {
@@ -64,7 +64,7 @@ export class Transport {
       this.createUrl(endpoint, params),
       body
     );
-    return this.withErrorHandling(() => this.context.fetcher.fetch(request));
+    return this.withErrorHandling(() => this.fetcher.fetch(request));
   }
 
 }

--- a/helpers.ts
+++ b/helpers.ts
@@ -45,9 +45,9 @@ export async function getMediaItemsFromAlbum(albumId: string, context: coda.Exec
     const response = await photos.mediaItems.search(albumId, 'mediaItems(id),nextPageToken', pageSize, nextPageToken)
     const mediaItemsRes = response.body?.mediaItems as types.MediaItemIdRes[];
     if (mediaItemsRes) {
-      mediaItems = mediaItems.concat(mediaItemsRes.map((mediaItem) => {
+      mediaItems = mediaItemsRes.map((mediaItem) => {
         return { mediaId: mediaItem.id, filename: "Not found" }
-      }));
+      });
     }
     nextPageToken = response.body?.nextPageToken as string | undefined;
   } while (nextPageToken);

--- a/helpers.ts
+++ b/helpers.ts
@@ -59,16 +59,20 @@ export async function getMediaItemsFromAlbum(albumId: string, context: coda.Exec
 export function albumParser(albums: types.AlbumResponse[]): types.Album[] {
   return albums.map((album) => {
     let { id, title, productUrl, coverPhotoBaseUrl, coverPhotoMediaItemId } = album;
+    let coverPhotoMediaItem: types.Album['coverPhotoMediaItem'] = undefined;
+    if (coverPhotoMediaItemId) {
+      coverPhotoMediaItem = {
+        filename: "Not found",
+        mediaId: coverPhotoMediaItemId,
+      }
+    }
     return {
       albumId: id,
       title,
       url: productUrl,
       mediaItems: [],
       coverPhoto: `${coverPhotoBaseUrl}=w2048-h1024`,
-      coverPhotoMediaItem: {
-        filename: "Not found",
-        mediaId: coverPhotoMediaItemId,
-      },
+      coverPhotoMediaItem,
     }
   });
 }

--- a/helpers.ts
+++ b/helpers.ts
@@ -37,7 +37,7 @@ export function mediaItemsParser(mediaItems: types.MediaItemResponse[]): types.M
   });
 }
 
-export async function getMediaItemsFromAlbum(albumId: string, context: coda.ExecutionContext, pageSize = 25) {
+export async function getMediaItemsFromAlbum(albumId: string, context: coda.ExecutionContext, pageSize = 100) {
   const photos = new GPhotos(context);
   let mediaItems: types.Album['mediaItems'] = [];
   let nextPageToken: string | undefined;

--- a/helpers.ts
+++ b/helpers.ts
@@ -1,5 +1,5 @@
 import * as coda from "@codahq/packs-sdk";
-import * as types from "types/pack-types";
+import * as types from "types/common-types";
 import GPhotos from "./api";
 
 export async function getConnectionName(context: coda.ExecutionContext) {
@@ -37,37 +37,27 @@ export function mediaItemsParser(mediaItems: types.MediaItemResponse[]): types.M
   });
 }
 
-async function getMediaItems(
-  context: coda.ExecutionContext,
-  albumId: string,
-  continuation?: coda.Continuation | undefined,
-): Promise<any> {
-  let body: types.GetMediaItemsPayload = {
-    albumId,
-    pageSize: 100,
-  }
-  if (continuation) {
-    body.pageToken = continuation.nextMediaItemsPageToken as string;
-  }
-  let response = await context.fetcher.fetch({
-    method: "POST",
-    url: `${ApiUrl}/mediaItems:search`,
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(body),
-  });
-  let nextMediaItemsPageToken;
-  if (response.body.nextPageToken) {
-    nextMediaItemsPageToken = response.body.nextPageToken;
-  }
-  return {
-    result: response.body?.mediaItems ? mediaItemsParser(response.body.mediaItems) : undefined,
-    continuation: nextMediaItemsPageToken ? { nextMediaItemsPageToken } : undefined,
-  };
+export async function getMediaItemsFromAlbum(albumId: string, context: coda.ExecutionContext, pageSize = 25) {
+  const photos = new GPhotos(context);
+  let mediaItems: types.Album['mediaItems'] = [];
+  let nextPageToken: string | undefined;
+  do {
+    const response = await photos.mediaItems.search(albumId, 'mediaItems(id),nextPageToken', pageSize, nextPageToken)
+    const mediaItemsRes = response.body?.mediaItems as types.MediaItemIdRes[];
+    if (mediaItemsRes) {
+      mediaItems = mediaItems.concat(mediaItemsRes.map((mediaItem) => {
+        return { mediaId: mediaItem.id, filename: "Not found" }
+      }));
+    }
+    nextPageToken = response.body?.nextPageToken as string | undefined;
+  } while (nextPageToken);
+  // console.debug('found', mediaItems.length, 'medias in album', albumId)
+  return { mediaItems };
 }
 
 // Parse the response from the API to the format we want to return
 // Matches the AlbumSchema schema defined in ./schemas.ts
-function albumParser(albums: types.AlbumResponse[]): types.Album[] {
+export function albumParser(albums: types.AlbumResponse[]): types.Album[] {
   return albums.map((album) => {
     let { id, title, productUrl, coverPhotoBaseUrl, coverPhotoMediaItemId } = album;
     return {
@@ -76,43 +66,10 @@ function albumParser(albums: types.AlbumResponse[]): types.Album[] {
       url: productUrl,
       mediaItems: [],
       coverPhoto: `${coverPhotoBaseUrl}=w2048-h1024`,
-      coverPhotoMediaItem: coverPhotoMediaItemId,
+      coverPhotoMediaItem: {
+        filename: "Not found",
+        mediaId: coverPhotoMediaItemId,
+      },
     }
   });
-}
-
-export async function syncAlbums(
-  context: coda.SyncExecutionContext,
-): Promise<coda.GenericSyncFormulaResult> {
-  let url = `${ApiUrl}/albums`;
-  let { continuation } = context.sync;
-  if (continuation && continuation.nextAlbumsPageToken) {
-    url = coda.withQueryParams(url, { pageToken: continuation.nextAlbumsPageToken });
-  }
-  let response = await context.fetcher.fetch({
-    method: "GET",
-    url,
-    headers: { "Content-Type": "application/json" },
-  });
-  let nextAlbumsPageToken;
-  if (response.body.nextPageToken) {
-    nextAlbumsPageToken = response.body.nextPageToken;
-  }
-  let albums: types.Album[] = [];
-  if (response.body.albums) {
-    let albumsRes = response.body.albums as types.AlbumResponse[];
-    albums = albumParser(albumsRes);
-    albums.forEach(async (album) => {
-      do {
-        let mediaItemsRes = await getMediaItems(context, album.albumId, continuation);
-        ({ continuation } = mediaItemsRes);
-        album.mediaItems = mediaItemsRes.result;
-      } while (continuation && continuation.nextMediaItemsPageToken);
-    });
-  }
-
-  return {
-    result: albums,
-    continuation: nextAlbumsPageToken ? { nextAlbumsPageToken } : undefined,
-  };
 }

--- a/helpers.ts
+++ b/helpers.ts
@@ -51,7 +51,6 @@ export async function getMediaItemsFromAlbum(albumId: string, context: coda.Exec
     }
     nextPageToken = response.body?.nextPageToken as string | undefined;
   } while (nextPageToken);
-  // console.debug('found', mediaItems.length, 'medias in album', albumId)
   return { mediaItems };
 }
 

--- a/helpers.ts
+++ b/helpers.ts
@@ -45,9 +45,9 @@ export async function getMediaItemsFromAlbum(albumId: string, context: coda.Exec
     const response = await photos.mediaItems.search(albumId, 'mediaItems(id),nextPageToken', pageSize, nextPageToken)
     const mediaItemsRes = response.body?.mediaItems as types.MediaItemIdRes[];
     if (mediaItemsRes) {
-      mediaItems = mediaItemsRes.map((mediaItem) => {
+      mediaItems = mediaItems.concat(mediaItemsRes.map((mediaItem) => {
         return { mediaId: mediaItem.id, filename: "Not found" }
-      });
+      }));
     }
     nextPageToken = response.body?.nextPageToken as string | undefined;
   } while (nextPageToken);

--- a/helpers.ts
+++ b/helpers.ts
@@ -37,12 +37,12 @@ export function mediaItemsParser(mediaItems: types.MediaItemResponse[]): types.M
   });
 }
 
-export async function getMediaItemsFromAlbum(albumId: string, context: coda.ExecutionContext, pageSize = 100) {
+export async function getMediaItemsFromAlbum(albumId: string, context: coda.ExecutionContext) {
   const photos = new GPhotos(context.fetcher);
   let mediaItems: types.Album['mediaItems'] = [];
   let nextPageToken: string | undefined;
   do {
-    const response = await photos.mediaItems.search(albumId, 'mediaItems(id),nextPageToken', pageSize, nextPageToken)
+    const response = await photos.mediaItems.search(albumId, nextPageToken, 100, 'mediaItems(id),nextPageToken')
     const mediaItemsRes = response.body?.mediaItems as types.MediaItemIdRes[];
     if (mediaItemsRes) {
       mediaItems = mediaItems.concat(mediaItemsRes.map((mediaItem) => {

--- a/helpers.ts
+++ b/helpers.ts
@@ -38,7 +38,7 @@ export function mediaItemsParser(mediaItems: types.MediaItemResponse[]): types.M
 }
 
 export async function getMediaItemsFromAlbum(albumId: string, context: coda.ExecutionContext, pageSize = 100) {
-  const photos = new GPhotos(context);
+  const photos = new GPhotos(context.fetcher);
   let mediaItems: types.Album['mediaItems'] = [];
   let nextPageToken: string | undefined;
   do {

--- a/pack.ts
+++ b/pack.ts
@@ -73,6 +73,12 @@ pack.addSyncTable({
       // mediaTypeFilter.setType(mediaType as types.MediaTypes)
       filters.setMediaTypeFilter(mediaTypeFilter);
 
+      // Feature filter (favorites)
+      if (favorite) {
+        const featureFilter = new photos.FeatureFilter(types.MediaFeature.Favorites)
+        filters.setFeatureFilter(featureFilter);
+      }
+
       const response = await photos.mediaItems.search(
         filters,
         '',

--- a/pack.ts
+++ b/pack.ts
@@ -108,19 +108,19 @@ pack.addSyncTable({
       const photos = new GPhotos(context);
       const response = await photos.albums.list(20, (context.sync.continuation?.nextPageToken as string | undefined));
       const { albums, nextPageToken } = response?.body;
+      const parsedAlbums = albums ? helpers.albumParser(albums) : null;
 
-      let parsedAlbums = helpers.albumParser(albums)
-
-      parsedAlbums = await Promise.all(parsedAlbums.map(async (album) => {
-        const { albumId } = album;
-        const { mediaItems } = await helpers.getMediaItemsFromAlbum(albumId, context);
-        album.mediaItems = mediaItems;
-        return album;
-      }));
+      if (parsedAlbums) {
+        for (const album of parsedAlbums) {
+          const { albumId } = album;
+          const { mediaItems } = await helpers.getMediaItemsFromAlbum(albumId, context);
+          album.mediaItems = mediaItems ?? undefined;
+        }
+      }
 
       return {
         result: parsedAlbums,
-        continuation: nextPageToken
+        continuation: { nextPageToken }
       }
     }
   }

--- a/pack.ts
+++ b/pack.ts
@@ -89,7 +89,7 @@ pack.addSyncTable({
 
       return {
         result: mediaItems ? helpers.mediaItemsParser(mediaItems as types.MediaItemResponse[]) : null,
-        continuation: { nextPageToken }
+        continuation: nextPageToken ? { nextPageToken } : undefined
       }
     },
   },
@@ -120,7 +120,7 @@ pack.addSyncTable({
 
       return {
         result: parsedAlbums,
-        continuation: { nextPageToken }
+        continuation: nextPageToken ? { nextPageToken } : undefined
       }
     }
   }

--- a/pack.ts
+++ b/pack.ts
@@ -70,6 +70,7 @@ pack.addSyncTable({
 
       // Media type filter
       const mediaTypeFilter = new photos.MediaTypeFilter(mediaType as types.MediaTypes);
+      // mediaTypeFilter.setType(mediaType as types.MediaTypes)
       filters.setMediaTypeFilter(mediaTypeFilter);
 
       const response = await photos.mediaItems.search(

--- a/pack.ts
+++ b/pack.ts
@@ -40,7 +40,7 @@ pack.addSyncTable({
       params.MediaArchivedOptional,
     ],
     execute: async function ([dateRange, categoriesToInclude, categoriesToExclude, mediaType, favorite, archived], context) {
-      let photos = new GPhotos(context);
+      let photos = new GPhotos(context.fetcher);
 
       const filters = new photos.Filters(archived);
 
@@ -105,7 +105,7 @@ pack.addSyncTable({
     parameters: [],
     execute: async function ([], context) {
 
-      const photos = new GPhotos(context);
+      const photos = new GPhotos(context.fetcher);
       const response = await photos.albums.list(20, (context.sync.continuation?.nextPageToken as string | undefined));
       const { albums, nextPageToken } = response?.body;
       const parsedAlbums = albums ? helpers.albumParser(albums) : null;

--- a/pack.ts
+++ b/pack.ts
@@ -117,7 +117,6 @@ pack.addSyncTable({
         const { albumId } = album;
         const { mediaItems } = await helpers.getMediaItemsFromAlbum(albumId, context);
         album.mediaItems = mediaItems;
-        console.debug(album.mediaItems.length, 'medias in album', album.title)
         return album;
       }));
 

--- a/pack.ts
+++ b/pack.ts
@@ -79,12 +79,7 @@ pack.addSyncTable({
         filters.setFeatureFilter(featureFilter);
       }
 
-      const response = await photos.mediaItems.search(
-        filters,
-        '',
-        100,
-        (context.sync.continuation?.nextPageToken as string | undefined)
-      )
+      const response = await photos.mediaItems.search(filters, (context.sync.continuation?.nextPageToken as string | undefined))
       const { nextPageToken, mediaItems } = response?.body ?? {};
 
       return {

--- a/pack.ts
+++ b/pack.ts
@@ -99,19 +99,7 @@ pack.addSyncTable({
     execute: async function ([], context) {
 
       const photos = new GPhotos(context);
-      let response
-      try {
-        response = await photos.albums.list(20, (context.sync.continuation?.nextPageToken as string | undefined));
-      } catch (e) {
-        if (coda.StatusCodeError.isStatusCodeError(e)) {
-          let statusError = e as coda.StatusCodeError;
-          let message = statusError.body?.error?.message;
-          if (message) {
-            throw new coda.UserVisibleError(message);
-          }
-        }
-        throw e;
-      }
+      const response = await photos.albums.list(20, (context.sync.continuation?.nextPageToken as string | undefined));
       const { albums, nextPageToken } = response?.body;
 
       let parsedAlbums = helpers.albumParser(albums)

--- a/schemas.ts
+++ b/schemas.ts
@@ -74,7 +74,7 @@ export const AlbumSchema = coda.makeObjectSchema({
       description: "Google Photos URL for the album.",
       codaType: coda.ValueHintType.Url,
     },
-    mediasItems: {
+    mediaItems: {
       type: coda.ValueType.Array,
       items: MediaReferenceSchema
     },

--- a/schemas.ts
+++ b/schemas.ts
@@ -29,11 +29,8 @@ const MediaMetadataSchema = coda.makeObjectSchema({
 
 export const MediaSchema = coda.makeObjectSchema({
   properties: {
-    mediaId: {
-      type: coda.ValueType.String,
-      required: true
-    },
-    filename: { type: coda.ValueType.String, required: true },
+    mediaId: { type: coda.ValueType.String },
+    filename: { type: coda.ValueType.String },
     mediaType: { type: coda.ValueType.String },
     mimeType: { type: coda.ValueType.String },
     description: { type: coda.ValueType.String },
@@ -61,7 +58,18 @@ export const MediaSchema = coda.makeObjectSchema({
   ],
 });
 
-const MediaReferenceSchema = coda.makeReferenceSchemaFromObjectSchema(MediaSchema, "Media");
+const MediaReferenceSchema = coda.makeObjectSchema({
+  codaType: coda.ValueHintType.Reference,
+  properties: {
+    filename: { type: coda.ValueType.String, required: true },
+    mediaId: { type: coda.ValueType.String, required: true },
+  },
+  displayProperty: "filename",
+  idProperty: "mediaId",
+  identity: {
+    name: "Media",
+  },
+});
 
 export const AlbumSchema = coda.makeObjectSchema({
   properties: {

--- a/types/api-types.ts
+++ b/types/api-types.ts
@@ -36,8 +36,10 @@ interface ContributorInfo {
   displayName: string;
 }
 
-export interface MediaItemResponse {
-  id: string;
+export interface MediaItemIdRes {
+  id: string,
+};
+export interface MediaItemResponse extends MediaItemIdRes {
   description: string;
   productUrl: string;
   baseUrl: string;
@@ -131,7 +133,7 @@ export interface MediaItemsFilter {
 }
 
 export interface ApiResponse {
-  mediaItems?: MediaItemResponse[];
+  mediaItems?: MediaItemResponse[] | MediaItemIdRes[];
   albums?: AlbumResponse[];
   sharedAlbums?: object[];
   nextPageToken?: string;

--- a/types/api-types.ts
+++ b/types/api-types.ts
@@ -109,6 +109,11 @@ export enum MediasContentCategories {
   Whiteboards = "WHITEBOARDS",
 }
 
+export enum MediaFeature {
+  None = "NONE",
+  Favorites = "FAVORITES",
+}
+
 // filter object when "searching" for media items
 export interface MediaItemsFilter {
   dateFilter?: {
@@ -126,7 +131,7 @@ export interface MediaItemsFilter {
     mediaTypes: MediaTypes[],
   }
   featureFilter?: {
-    includedFeatures: ["NONE" | "FAVORITES"],
+    includedFeatures: [MediaFeature],
   };
   includeArchivedMedia?: boolean;
   excludeNonAppCreatedData?: boolean;

--- a/types/common-types.ts
+++ b/types/common-types.ts
@@ -1,0 +1,2 @@
+export { ApiResponse, MediaItemIdRes, MediaItemResponse, AlbumResponse } from "./api-types";
+export { MediaItemId, MediaItem, Album } from "./pack-types"

--- a/types/pack-types.ts
+++ b/types/pack-types.ts
@@ -1,8 +1,11 @@
 import { ShareInfo } from "./api-types";
 // Pack types
 
-export interface MediaItem {
-  mediaId: string;
+export interface MediaItemId {
+  mediaId: string,
+}
+
+export interface MediaItem extends MediaItemId {
   filename: string;
   mediaType: string;
   mimeType: string;
@@ -14,12 +17,16 @@ export interface MediaItem {
   url: string;
 }
 
+export interface MediaItemReference extends MediaItemId {
+  filename: "Not found";
+}
+
 export interface Album {
   albumId: string;
   title: string;
   url: string;
   shareInfo?: ShareInfo;
-  mediaItems: MediaItem[];
+  mediaItems: MediaItemReference[];
   coverPhoto: string;
-  coverPhotoMediaItem: string | undefined; // TODO: find a way to make this a MediaItem
+  coverPhotoMediaItem: MediaItemReference;
 }

--- a/types/pack-types.ts
+++ b/types/pack-types.ts
@@ -26,7 +26,7 @@ export interface Album {
   title: string;
   url: string;
   shareInfo?: ShareInfo;
-  mediaItems: MediaItemReference[];
+  mediaItems: MediaItemReference[] | undefined;
   coverPhoto: string;
-  coverPhotoMediaItem: MediaItemReference;
+  coverPhotoMediaItem: MediaItemReference | undefined;
 }


### PR DESCRIPTION
This PR modifies code on several files to replace existing Google Photos API requests with calls to methods of `GPhotos` class, improving consistency and organization.

**You can now link albums and medias.** (closes #5 )

- Changes the `search` method in `mediaItems` class to support `fields` parameter (better performance when fetching only `mediaItems ids`).
- Also tweaks the `getMediaItemsFromAlbum` function to use the new `mediaItems.search` method.
- Finally, refactored the `Album` interface using a new `MediaItemReference` interface.

### Todo

Needs more stuff tbd before merging:

- [x] Refactor `SyncAlbums`
- [x] Link Albums and Medias
- [x] `favorite` filter on Medias SyncTable
- [x] TypeScript warning on execute method
- [x] Better error handling
- [x] See comments